### PR TITLE
Corrected try-catch Flag IsAvailable comparison

### DIFF
--- a/Unosquare.PiGpio/Board.cs
+++ b/Unosquare.PiGpio/Board.cs
@@ -22,11 +22,25 @@
                 var config = (int)Setup.GpioCfgGetInternals();
 
                 // config = config.ApplyBits(false, 3, 2, 1, 0); // Clear debug flags
-                // config = config | (int)ConfigFlags.NoSignalHandler;
+                /*
+                MJA
+                If you use Visual Studio 2019 together with VSMonoDebugger and X11 remote debugging,
+                you need to enable the next line, otherwise Mono will catch the Signals and stop
+                debugging immediately although native started program will work ok
+                */
+                config = config | (int)ConfigFlags.NoSignalHandler;
                 Setup.GpioCfgSetInternals((ConfigFlags)config);
 
                 var initResultCode = Setup.GpioInitialise();
-                IsAvailable = initResultCode == ResultCode.Ok;
+                /*
+                MJA
+                Setup.GpioInitialise() gives back value greater than zero if it has success.
+                More in detail:
+                The given back number is the version of the library version you use on RasPi.
+                Therefore a greater or equal comparison would make potentially more sense.
+                */
+                // IsAvailable = initResultCode == ResultCode.Ok;
+                IsAvailable = initResultCode >= ResultCode.Ok;
 
                 // You will need to compile libgpio.h adding
                 // #define EMBEDDED_IN_VM


### PR DESCRIPTION
Hi, 
this small fix allowed my to declare my variables in my WinApplicationForm without crashing while debugging.

Seldomwise with the declaration of pure GPIO's the error was not there .. when I added a I2cDevice it crashed.

Example declaration:
private I2cDevice _myDevice = Board.Peripherals.OpenI2cDevice(I2cBusId.Bus1, _addr1);
private GpioPin _LedPin17 = Board.Pins[SystemGpio.Bcm17];

Now it works perfectly.

Thanks a lot for this excellent C# wrapper .. hope the RaspberryIO-wrapper will support this very soon, too.

Best regards
Marco

PS: Here my small test program
[Board_Test.zip](https://github.com/unosquare/pigpio-dotnet/files/3873788/Board_Test.zip)
