### PR TITLE
Fix < 1ms TimeSpan's to be Sleep(0)

### DIFF
--- a/Unosquare.PiGpio/ManagedModel/BoardTimingService.cs
+++ b/Unosquare.PiGpio/ManagedModel/BoardTimingService.cs
@@ -99,8 +99,17 @@
         /// Sleeps for the specified time span.
         /// </summary>
         /// <param name="timeSpan">The time span to sleep for.</param>
-        public void Sleep(TimeSpan timeSpan) =>
-            Sleep(Convert.ToInt64(timeSpan.TotalMilliseconds));
+        public void Sleep(TimeSpan timeSpan)
+        {
+            var micros = timeSpan.Ticks / (TimeSpan.TicksPerMillisecond / 1000);
+
+            if (micros > uint.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeSpan), "Sleep length is too long.");
+            }
+
+            SleepMicroseconds((uint)micros);
+        }
 
         /// <summary>
         /// Shortcut method to start a thread.


### PR DESCRIPTION
Instead of calling out to the Millisecond based sleep method, it's
better to call to the Microsecond based sleep method.

```
var ts = TimeSpan.FromMilliseconds(.5);
var millis = Convert.ToInt64(ts.TotalMilliseconds);
var micros = ts.Ticks / (TimeSpan.TicksPerMillisecond / 1000);
```

In this example, `millis == 0`, and `micros == 500`.

If `Sleep(TimeSpan` was called with that `ts` it would effectively be
`Sleep(0)` which can be problematic.