### PR TITLE
bugfix PinsToBitmask

### DIFF
--- a/Unosquare.PiGpio/ManagedModel/WaveBuilder.cs
+++ b/Unosquare.PiGpio/ManagedModel/WaveBuilder.cs
@@ -229,12 +229,12 @@
         /// <returns>A bitmask with each pin as a position.</returns>
         private static BitMask PinsToBitMask(IEnumerable<UserGpio> pins)
         {
-            const int bitMask = 0;
+            int bitMask = 0;
             
             if (pins != null)
             {
                 foreach (var pin in pins)
-                    bitMask.SetBit((int)pin, true);
+                    bitMask = bitMask.SetBit((int)pin, true);
             }
 
             return (BitMask)bitMask;


### PR DESCRIPTION
static method PinsToBitMask in WaveBuilder.cs always returns 0.
The return value of bitMask.SetBit((int)pin, true) needs to be used in an assignment.